### PR TITLE
Add checkError to every _request call

### DIFF
--- a/src/bitbutler.sh
+++ b/src/bitbutler.sh
@@ -654,7 +654,7 @@ function webhook() {
       [[ -n "$repo" ]] || die "Required argument 'repo' missing"
 
       response=$(_request GET "$endpoint?fields=values.uuid,values.description")
-      checkError $response
+      checkError "$response"
       echo -n "$response" | jq -r '.values[] | [.uuid, .description] | @tsv'
       ;;
     add)

--- a/src/bitbutler.sh
+++ b/src/bitbutler.sh
@@ -567,8 +567,9 @@ function restriction() {
 
   case "$subCmd" in
     list)
-      _request GET "/repositories/${bitbucket_owner}/$repo/branch-restrictions?pagelen=100" |
-        jq -r '.values[] | [.pattern, .kind, .value]'
+      response=$(_request GET "/repositories/${bitbucket_owner}/$repo/branch-restrictions?pagelen=100")
+      checkError "$response"
+      echo -n "$response" | jq -r '.values[] | [.pattern, .kind, .value]'
       ;;
     *)
       die "Unknown subcommand given: '$subCmd'"
@@ -589,8 +590,9 @@ function reviewer() {
 
   case "$subCmd" in
     list)
-      _request GET "$endpoint" |
-        jq -r '.values[] | [.nickname] | @tsv'
+      response=$(_request GET "$endpoint")
+      checkError "$response"
+      echo -n "$response" | jq -r '.values[] | [.nickname] | @tsv'
       ;;
     add)
       [[ -n "$username" ]] || die "Required argument 'username' missing"
@@ -627,8 +629,9 @@ function team() {
 
   case "$subCmd" in
     members)
-      _request GET "$endpoint/members" |
-        jq -r '.values[] | [.nickname] | @tsv'
+      response=$(_request GET "$endpoint/members")
+      checkError "$response"
+      echo -n "$response" | jq -r '.values[] | [.nickname] | @tsv'
       ;;
     *)
       die "Unknown subcommand given: '$subCmd'"
@@ -650,8 +653,9 @@ function webhook() {
     list)
       [[ -n "$repo" ]] || die "Required argument 'repo' missing"
 
-      _request GET "$endpoint?fields=values.uuid,values.description" |
-        jq -r '.values[] | [.uuid, .description] | @tsv'
+      response=$(_request GET "$endpoint?fields=values.uuid,values.description")
+      checkError $response
+      echo -n "$response" | jq -r '.values[] | [.uuid, .description] | @tsv'
       ;;
     add)
       [[ -n "$repo" ]] || die "Required argument 'repo' missing"


### PR DESCRIPTION
Added error checking for every request as it was not used everywhere. For example not having the correct access token scope led to the error message `jq: error (at <stdin>:0): Cannot iterate over null (null)` instead of a nice explanation what went wrong.

There was already one failed test in the version at `679d5c5` with the message: 
```
✗ _request - basic parameters                                                                                         
   (in test file tests/unit.bats, line 70)
     `[[ "${capture[0]}" =~ "curl-stub -s -X GET -H Accept: application/json -H Content-Type: application/json -u dummy:super-secret-password" ]]' failed
```
~A new failure was introduced with this code change:~ _solved_

```
✗ webhook - list
   (in test file tests/unit.bats, line 228)
     `[[ "$status" = "0" ]]' failed
```

However, I'm not very good with the bats test suite, so can you check if those are legitimate errors which need fixing or errors in the test itself?