### PR TITLE
Fix PR tests failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             sed -ri "s#<source>(.+)/</source>#<source>\1</source>#" "$xml"
 
             /tmp/cc-test-reporter format-coverage $xml --input-type cobertura
-            /tmp/cc-test-reporter upload-coverage
+            /tmp/cc-test-reporter upload-coverage || /bin/true
 
       - store_artifacts:
           path: coverage


### PR DESCRIPTION
Tests on PRs from forked repos failed due to missing secret for the test
coverage reporter. Worked around that by allowing the coverage upload to
fail. This _also_ solves an issue with running coverage reporting for
the same commit twice, as that one would also return an error in the
uploading step.

Secrets are by default not included in forked runs, as they could be
stolen, Circle-CI has a big warning note on that.