### PR TITLE
Extend .gitignore by IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 coverage/
 shellmock.out
 shellmock.err
+
+# Ignore directories created by IDEs
+.idea/
+.vscode/
+.history/


### PR DESCRIPTION
The .gitignore now excludes all files created by an IDE. Currently
covers `.idea` (JetBrains IDEs), `.vscode` and `.history` (both
Visual Studio Code).